### PR TITLE
normalize prefix

### DIFF
--- a/configurator.py
+++ b/configurator.py
@@ -11,7 +11,7 @@ def scan_args():
     target_file=""
     compiler_type=""
     compiler_executable=""
-    prefix=""
+    prefix="/usr"
 
     target_flie_given=False
     i=0

--- a/configure
+++ b/configure
@@ -9,7 +9,7 @@ def main():
     target_file="targets"
     compiler_type="gcc"
     compiler_executable="gcc"
-    prefix=""
+    prefix="/usr"
 
     i=0
     while i<len(args):

--- a/targets
+++ b/targets
@@ -182,10 +182,10 @@
             "blessings_utf8_static",
             "blessings_utf8_shared"
         ],
-        "static_libs_path" : "usr/lib",
-        "shared_libs_path" : "usr/lib",
-        "executable_path" : "usr/bin",
-        "includes_path" : "usr/include/blessings"
+        "static_libs_path" : "lib",
+        "shared_libs_path" : "lib",
+        "executable_path" : "bin",
+        "includes_path" : "include/blessings"
     },
     "uninstall" : {
         "target_type" : "uninstall",
@@ -196,9 +196,9 @@
             "blessings_utf8_static",
             "blessings_utf8_shared"
         ],
-        "static_libs_path" : "usr/lib",
-        "shared_libs_path" : "usr/lib",
-        "executable_path" : "usr/bin",
-        "headers_pathes" : ["usr/include/blessings"]
+        "static_libs_path" : "lib",
+        "shared_libs_path" : "lib",
+        "executable_path" : "bin",
+        "headers_pathes" : ["include/blessings"]
     }
 }


### PR DESCRIPTION
Usually when specifying prefix we let the user change the `/usr` component, for things like `/usr/local/include`.  This change lets that happen.